### PR TITLE
Typo in `compress_impl!` for GlobalRefs

### DIFF
--- a/src/ngg/compact.jl
+++ b/src/ngg/compact.jl
@@ -232,7 +232,7 @@ end
 
 function compress_impl!(a::GlobalRef)
     _, mod_encoded = compress_impl!(a.mod)
-    _, name_encoded = compress_impl!(a.mod)
+    _, name_encoded = compress_impl!(a.name)
     meta = SimpleMeta(1)
     encoded = Call(Constructor{GlobalRef}(), tuple(mod_encoded, name_encoded))
     return meta, encoded


### PR DESCRIPTION
I noticed this when CompatHelper's attempt to bump Catlab to GeneralizedGenerated v0.3 failed (https://github.com/AlgebraicJulia/Catlab.jl/pull/392).

```
MethodError: no method matching GlobalRef(::Module, ::Module)
  Closest candidates are:
    GlobalRef(::Module, !Matched::Symbol) at boot.jl:390
  Stacktrace:
   [1] (::GeneralizedGenerated.NGG.Constructor{GlobalRef})(::Any, ::Vararg{Any,N} where N) at /home/runner/.julia/packages/GeneralizedGenerated/bbOkX/src/ngg/compact.jl:220
   [2] decompress_impl(::GeneralizedGenerated.NGG.Call, ::Tuple) at /home/runner/.julia/packages/GeneralizedGenerated/bbOkX/src/ngg/compact.jl:186
```